### PR TITLE
Chore: definido flujo de Maven

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,17 @@
+name: Java CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: "11"
+          distribution: "adopt"
+      - name: Build with Maven
+        run: mvn --batch-mode --update-snapshots verify


### PR DESCRIPTION
Acorde con lo que hemos definido en el documento _A2.7. Configuration management methodology report_, he implementado el flujo de GitHub Actions para compilar automáticamente el proyecto Maven. Dicha funcionalidad no se identifica con ninguna tarea concreta del product backlog.

Closes #30 