### PR TITLE
Feat: hecha la tarea A4.E.1.1

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/configuration/SecurityConfiguration.java
+++ b/src/main/java/org/springframework/samples/petclinic/configuration/SecurityConfiguration.java
@@ -39,8 +39,14 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 				.permitAll().antMatchers("/admin/**").hasAnyAuthority(admin)
 				.antMatchers("/owners/**").hasAnyAuthority(owner, admin).antMatchers("/vets/**")
 				.authenticated().antMatchers("/causes/**").authenticated()
-				.antMatchers("/adoption/**").hasAnyAuthority(owner).anyRequest().denyAll().and()
-				.formLogin()
+				.antMatchers("/adoption/**").hasAnyAuthority(owner)
+				.antMatchers("/users/changePassword").hasAuthority("owner").anyRequest().denyAll()
+				.and().formLogin()
+
+				// TODO cambiar de contraseñas ahora mismo está soportado sólo para owners. Puede
+				// que haya que modificar esto cuando haya roles distintos que puedan cambiar su
+				// contraseña (por ejemplo clínicas)
+
 				/* .loginPage("/login") */
 				.failureUrl("/login-error").and().logout().logoutSuccessUrl("/");
 		// Configuración para que funcione la consola de administración

--- a/src/main/java/org/springframework/samples/petclinic/user/PasswordDTO.java
+++ b/src/main/java/org/springframework/samples/petclinic/user/PasswordDTO.java
@@ -1,0 +1,40 @@
+package org.springframework.samples.petclinic.user;
+
+public class PasswordDTO {
+    String userPassword;
+    String currentPassword;
+    String newPassword;
+    String confirmPassword;
+
+    public String getUserPassword() {
+        return userPassword;
+    }
+
+    public void setUserPassword(String userPassword) {
+        this.userPassword = userPassword;
+    }
+
+    public String getCurrentPassword() {
+        return currentPassword;
+    }
+
+    public void setCurrentPassword(String currentPassword) {
+        this.currentPassword = currentPassword;
+    }
+
+    public String getNewPassword() {
+        return newPassword;
+    }
+
+    public void setNewPassword(String newPassword) {
+        this.newPassword = newPassword;
+    }
+
+    public String getConfirmPassword() {
+        return confirmPassword;
+    }
+
+    public void setConfirmPassword(String confirmPassword) {
+        this.confirmPassword = confirmPassword;
+    }
+}

--- a/src/main/java/org/springframework/samples/petclinic/user/UserController.java
+++ b/src/main/java/org/springframework/samples/petclinic/user/UserController.java
@@ -1,24 +1,21 @@
 /*
  * Copyright 2002-2013 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 package org.springframework.samples.petclinic.user;
 
 import java.util.Map;
-
+import java.util.Objects;
 import javax.validation.Valid;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.samples.petclinic.owner.Owner;
 import org.springframework.samples.petclinic.owner.OwnerService;
@@ -28,6 +25,7 @@ import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.InitBinder;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 /**
  * @author Juergen Hoeller
@@ -39,12 +37,15 @@ import org.springframework.web.bind.annotation.PostMapping;
 public class UserController {
 
 	private static final String VIEWS_OWNER_CREATE_FORM = "users/createOwnerForm";
+	private static final String VIEWS_OWNER_CHANGE_PASSWORD_FORM = "users/changePasswordForm";
 
 	private final OwnerService ownerService;
+	private final UserService userService;
 
 	@Autowired
-	public UserController(OwnerService clinicService) {
+	public UserController(OwnerService clinicService, UserService userService) {
 		this.ownerService = clinicService;
+		this.userService = userService;
 	}
 
 	@InitBinder
@@ -63,10 +64,64 @@ public class UserController {
 	public String processCreationForm(@Valid Owner owner, BindingResult result) {
 		if (result.hasErrors()) {
 			return VIEWS_OWNER_CREATE_FORM;
-		}
-		else {
-			//creating owner, user, and authority
+		} else {
+			// creating owner, user, and authority
 			this.ownerService.saveOwner(owner);
+			return "redirect:/";
+		}
+	}
+
+	@GetMapping(value = "/users/changePassword")
+	public String initChangePasswordForm(Map<String, Object> model) {
+		PasswordDTO values = new PasswordDTO();
+		String username = userService.getCurrentUserName();
+		User user = userService.findUser(username).orElse(null);
+		if (user != null) {
+			values.setUserPassword(user.getPassword());
+		}
+		model.put("values", values);
+		return VIEWS_OWNER_CHANGE_PASSWORD_FORM;
+	}
+
+	@PostMapping(value = "/users/changePassword")
+	public String processChangePasswordForm(PasswordDTO values, BindingResult result,
+			RedirectAttributes redirectAttributes) {
+		if (result.hasErrors()) {
+			return VIEWS_OWNER_CHANGE_PASSWORD_FORM;
+		} else {
+			// creating owner, user, and authority
+			var currentPassword = values.getCurrentPassword();
+			var newPasword = values.getNewPassword();
+			var confirmPassword = values.getConfirmPassword();
+
+			String username = userService.getCurrentUserName();
+			User user = userService.findUser(username).orElse(null);
+
+			if (Objects.isNull(user)) {
+				redirectAttributes.addFlashAttribute("message", "Usuario no encontrado");
+				return VIEWS_OWNER_CHANGE_PASSWORD_FORM;
+			}
+
+			if (Objects.isNull(currentPassword) || Objects.isNull(newPasword)
+					|| Objects.isNull(confirmPassword)) {
+				redirectAttributes.addFlashAttribute("message",
+						"Todos los campos son obligatorios");
+				return VIEWS_OWNER_CHANGE_PASSWORD_FORM;
+			}
+			if (!currentPassword.equals(user.getPassword())) {
+				redirectAttributes.addFlashAttribute("message",
+						"La contraseña no coincide con la actual");
+				return VIEWS_OWNER_CHANGE_PASSWORD_FORM;
+			}
+
+			if (!newPasword.equals(confirmPassword)) {
+				redirectAttributes.addFlashAttribute("message",
+						"La contraseña nueva no coincide con la confirmación");
+				return VIEWS_OWNER_CHANGE_PASSWORD_FORM;
+			}
+
+			user.setPassword(newPasword);
+			this.userService.saveUser(user);
 			return "redirect:/";
 		}
 	}

--- a/src/main/webapp/WEB-INF/jsp/users/changePasswordForm.jsp
+++ b/src/main/webapp/WEB-INF/jsp/users/changePasswordForm.jsp
@@ -1,0 +1,72 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
+<%@ page session="false" trimDirectiveWhitespaces="true" %>
+<%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="form" uri="http://www.springframework.org/tags/form" %>
+<%@ taglib prefix="petclinic" tagdir="/WEB-INF/tags" %>
+
+<petclinic:layout pageName="owners">
+    <h2>
+        Cambiar contraseña
+    </h2>
+    <form:form modelAttribute="values" class="form-horizontal" id="change-password-form">
+        <div class="form-group has-feedback">
+            <div style="display: none;">
+            <petclinic:inputField type="password" label="Contaseña" name="userPassword"/>
+            </div>
+            <petclinic:inputField type="password" label="Contraseña actual" name="currentPassword"/>
+            <petclinic:inputField type="password" label="Contraseña nueva" name="newPassword"/>
+            <petclinic:inputField type="password" label="Confirmar contraseña" name="confirmPassword" />
+        </div>
+        <button class="btn btn-default" type="button" id="update" onclick="javascript:ValidateForm()">Actualizar</button>
+        <button class="btn btn-default" type="button" id="generate-password" onclick="javascript:GeneratePassword()">Generar contraseña segura</button>
+
+        <script type="text/javascript">
+            ValidateForm = function() {
+                var userPassword = document.forms["change-password-form"]["userPassword"].value;
+                var currentPassword = document.forms["change-password-form"]["currentPassword"].value;
+                var newPassword = document.forms["change-password-form"]["newPassword"].value;
+                var confirmPassword = document.forms["change-password-form"]["confirmPassword"].value;
+
+                if (newPassword.length < 4) {
+                    alert("La contraseña debe tener al menos 4 caracteres");
+                    return false;
+                }
+                if (userPassword != currentPassword) {
+                    alert("La contraseña actual no es correcta");
+                    return false;
+                }
+
+                if (newPassword !== confirmPassword) {
+                    alert("Las contraseñas no coinciden");
+                    return false;
+                }
+                document.querySelector("#change-password-form").submit();
+            }
+
+            GeneratePassword = async function() {
+                const options = {
+                    method: 'POST',
+                    headers: {
+                        'content-type': 'application/json',
+                        'X-RapidAPI-Host': 'passwordgen.p.rapidapi.com',
+                        'X-RapidAPI-Key': '0d9a6f16camsh11dff2b762fab22p1e2b05jsn2ab9693be005'
+                    },
+                    body: '{"isUpperCase":true,"isLowerCase":true,"isNumber":true,"isSymbol":false,"maxLength":12}'
+                };
+
+                fetch('https://passwordgen.p.rapidapi.com/api/v1/custom-password', options)
+                    .then(response => response.json())
+                    .then(body => {
+                        var securePassword = body.password
+                        alert("Tu nueva contraseña segura es " + securePassword +". Cópiala antes de enviarla, no la podrás volver a ver!");
+                        document.forms["change-password-form"]["newPassword"].value = securePassword;
+                        document.forms["change-password-form"]["confirmPassword"].value = securePassword;
+                    })
+                    .catch(err => console.error(err));
+            }
+        </script>
+    </form:form>
+</petclinic:layout>

--- a/src/main/webapp/WEB-INF/tags/inputField.tag
+++ b/src/main/webapp/WEB-INF/tags/inputField.tag
@@ -5,6 +5,8 @@
               description="Name of corresponding property in bean object" %>
 <%@ attribute name="label" required="true" rtexprvalue="true"
               description="Label appears in red color if input is considered as invalid after submission" %>
+<%@ attribute name="type" required="false" rtexprvalue="true"
+              description="text, password..." %>
 
 <spring:bind path="${name}">
     <c:set var="cssGroup" value="form-group ${status.error ? 'has-error' : '' }"/>
@@ -13,7 +15,7 @@
         <label class="col-sm-2 control-label">${label}</label>
 
         <div class="col-sm-10">
-            <form:input class="form-control" path="${name}"/>
+            <form:input class="form-control" type="${type != null ? type : 'text'}" path="${name}"/>
             <c:if test="${valid}">
                 <span class="glyphicon glyphicon-ok form-control-feedback" aria-hidden="true"></span>
             </c:if>

--- a/src/main/webapp/WEB-INF/tags/menu.tag
+++ b/src/main/webapp/WEB-INF/tags/menu.tag
@@ -89,6 +89,10 @@
 											
 													
 													<p class="text-left">
+													<a href="<c:url value="/users/changePassword" />"
+													class="btn btn-primary btn-block btn-sm">Cambiar contraseña</a>
+													
+													<p class="text-left">
 												<a href="<c:url value="/logout" />"
 													class="btn btn-primary btn-block btn-sm">Salir</a>
 													


### PR DESCRIPTION
Los owners ahora pueden cambiar su contraseña. Al tener la sesión iniciada aparecerá el botón "Cambiar contraseña" en el menú dropdown de arriba a la derecha, el que tiene el nombre del usuario.

Al cambiar la contraseña hay un botón "Generar contraseña segura" que se comunica con una API externa que nos genera dichas contraseñas, informa al usuario de la que se ha elegido y rellena automáticamente los campos (se ha hecho con ayuda de Javascript en la vista).

Se realizan las comprobaciones que he pensado que podían ser necesarias:
* La antigua contraseña debe introducirse correctamente
* La nueva contraseña no puede tener menos de 4 caracteres
* Es necesario confirmar la nueva contraseña, y que coincida con la del campo de arriba